### PR TITLE
fix(objects): set providerconfig for objects always to remote

### DIFF
--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -1092,6 +1092,9 @@ spec:
       patches:
         - type: FromCompositeFieldPath
           fromFieldPath: spec.parameters.id
+          toFieldPath: spec.providerConfigRef.name
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.id
           toFieldPath: spec.forProvider.manifest.metadata.name
           transforms:
             - type: string
@@ -1217,6 +1220,9 @@ spec:
                 namespace: upbound-system
               type: Opaque
       patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.id
+          toFieldPath: spec.providerConfigRef.name
         - type: FromCompositeFieldPath
           fromFieldPath: spec.parameters.id
           toFieldPath: spec.forProvider.manifest.metadata.name
@@ -1370,6 +1376,9 @@ spec:
                 namespace: upbound-system
               type: Opaque
       patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.id
+          toFieldPath: spec.providerConfigRef.name
         - type: FromCompositeFieldPath
           fromFieldPath: spec.parameters.id
           toFieldPath: spec.forProvider.manifest.metadata.name


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
- set providerconfig for objects always to remote 
- InjectedIdentity for provider-kubernetes is not available for Upbound-SaaS
- this PR avoid handmade interaction with controlplane

![image](https://github.com/upbound/platform-ref-aws-cnoe/assets/21083497/626f8095-01b8-40f0-afdb-533382b46ca5)


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
