### PR TITLE
Move function-p&t from upbound to crossplane-contrib

### DIFF
--- a/examples/render/functions.yaml
+++ b/examples/render/functions.yaml
@@ -1,6 +1,6 @@
 apiVersion: pkg.crossplane.io/v1beta1
 kind: Function
 metadata:
-  name: upbound-function-patch-and-transform
+  name: crossplane-contrib-function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/upbound/function-patch-and-transform:v0.2.1
+  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.2.1


### PR DESCRIPTION
### Description of your changes
The Upbound fork of function-patch-and-transform has been retired. This PR moves the composition to the crossplane-contrib repository

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] ~Run `make reviewable` to ensure this PR is ready for review.~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested
- [x] Run `make render` to confirm the composition renders correctly