### PR TITLE
Add Route53 and IAM role secrets to E2E workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,6 +14,8 @@ env:
   UP_ORG: ${{ secrets.UP_E2E_ORG || secrets.UP_ORG }}
   UP_GROUP: ${{ secrets.UP_E2E_GROUP || secrets.UP_GROUP || 'default' }}
   UP_ROBOT_ID: ${{ secrets.UP_E2E_ROBOT_ID || secrets.UP_ROBOT_ID }}
+  ROUTE53_ZONE_ID: ${{ secrets.E2E_ROUTE53_ZONE_ID }}
+  IAM_ROLE_ARN: ${{ secrets.E2E_IAM_ROLE_ARN }}
 
 jobs:
   e2e:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,8 +14,6 @@ env:
   UP_ORG: ${{ secrets.UP_E2E_ORG || secrets.UP_ORG }}
   UP_GROUP: ${{ secrets.UP_E2E_GROUP || secrets.UP_GROUP || 'default' }}
   UP_ROBOT_ID: ${{ secrets.UP_E2E_ROBOT_ID || secrets.UP_ROBOT_ID }}
-  ROUTE53_ZONE_ID: ${{ secrets.E2E_ROUTE53_ZONE_ID }}
-  IAM_ROLE_ARN: ${{ secrets.E2E_IAM_ROLE_ARN }}
 
 jobs:
   e2e:
@@ -27,7 +25,14 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-
+          
+      - name: Export project-specific environment variables
+        if: secrets.E2E_EXTRA != ''
+        env:
+          E2E_EXTRA: ${{ secrets.E2E_EXTRA }}
+        run: |
+          echo "$E2E_EXTRA" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> $GITHUB_ENV
+          
       - name: Install and login with up
         if: env.UP_API_TOKEN != '' && env.UP_ORG != ''
         uses: upbound/action-up@53fe6395637d884c80d2bbc8c2d75d0ece776ced # v1


### PR DESCRIPTION
Only for Cnoe.Add environment variables for Route53 and IAM role in E2E tests.

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #
- Added ENV variables to keep the sensitive information away.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
